### PR TITLE
Remove work calendar requirement

### DIFF
--- a/netsuitesdk/api/vendors.py
+++ b/netsuitesdk/api/vendors.py
@@ -105,8 +105,6 @@ class Vendors(ApiBase):
 
         vendor['representingSubsidiary'] = self.ns_client.RecordRef(**(data['representingSubsidiary']))
 
-        vendor['workCalendar'] = self.ns_client.RecordRef(**(data['workCalendar']))
-
         self.build_simple_fields(self.SIMPLE_FIELDS, data, vendor)
 
         self.build_record_ref_fields(self.RECORD_REF_FIELDS, data, vendor)


### PR DESCRIPTION
This is not required by the Netsuite API in order to create a vendor even though the docs we found said it is.

Our Netsuite account does not even appear to have this feature at all. If we encounter a customer who has this feature enabled there is the possibility of problems arising, but we'll have to deal with that if it happens.

The SDK provides no way to pull work calendars that I can see, so there's no way for us to programatically fetch data that could be passed here. So if this breaks for a customer we could have a fair bit of work on our hands.