### PR TITLE
Make representingSubsidiary optional

### DIFF
--- a/netsuitesdk/api/vendors.py
+++ b/netsuitesdk/api/vendors.py
@@ -103,7 +103,8 @@ class Vendors(ApiBase):
 
         vendor['subsidiary'] = self.ns_client.RecordRef(**(data['subsidiary']))
 
-        vendor['representingSubsidiary'] = self.ns_client.RecordRef(**(data['representingSubsidiary']))
+        if data.get('representingSubsidiary'):
+            vendor['representingSubsidiary'] = self.ns_client.RecordRef(**(data['representingSubsidiary']))
 
         self.build_simple_fields(self.SIMPLE_FIELDS, data, vendor)
 


### PR DESCRIPTION
In our testing it's not required and for some Netsuite accounts appears to actually not work. So let's not require that it be passed.