### PR TITLE
Allow creating/updating vendors with currencyList

### DIFF
--- a/netsuitesdk/api/vendors.py
+++ b/netsuitesdk/api/vendors.py
@@ -20,7 +20,6 @@ class Vendors(ApiBase):
         'comments',
         'companyName',
         'creditLimit',
-        'currencyList',
         'customFieldList',
         'dateCreated',
         'defaultAddress',
@@ -99,7 +98,11 @@ class Vendors(ApiBase):
         assert data['externalId'], 'missing external id'
         vendor = self.ns_client.Vendor(externalId=data['externalId'])
 
-        vendor['currency'] = self.ns_client.RecordRef(**(data['currency']))
+        if data.get('currency'):
+            vendor['currency'] = self.ns_client.RecordRef(**(data['currency']))
+
+        if data.get('currencyList'):
+            vendor['currencyList'] = self.ns_client.VendorCurrencyList(**(data['currencyList']))
 
         vendor['subsidiary'] = self.ns_client.RecordRef(**(data['subsidiary']))
 

--- a/netsuitesdk/internal/netsuite_types.py
+++ b/netsuitesdk/internal/netsuite_types.py
@@ -81,7 +81,7 @@ COMPLEX_TYPES = {
         'Customer', 'CustomerSearch', 'CustomerTaxRegistrationList', 'CustomerTaxRegistration',
         'Vendor', 'VendorSearch',
         'Job', 'JobSearch',
-        'VendorAddressbook', 'VendorAddressbookList',
+        'VendorAddressbook', 'VendorAddressbookList', 'VendorCurrencyList',
     ],
 
     # urn:accounting_2017_2.lists.webservices.netsuite.com


### PR DESCRIPTION
Previously you could only set one currency. We want to be able to create vendors in multiple currencies. In order to do this we needed to add `VendorCurrencyList` to the netsuite_types file.

The [schema][vendorCurrencyList] shows the namespace as:

```
urn:relationships.lists.webservices.netsuite.com
```

This indicates the section it should go in in the netsuite_types file. Under ns13, which has a comment above it with the same namespace.

This is apparently the "magic" of SOAP. Who wouldn't love it.

This magically makes `ns_client.VendorCurrencyList` a thing and as long as the data looks right it will work. We don't really have any code here that enforces what data should look like so I didn't add any for this. In float's backend we'll use TypedDicts to enforce type safety, but it matches the same structure as what gets returned for currencyList on a vendor.

[vendorCurrencyList]: https://www.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2019_1/schema/other/vendorcurrencylist.html?mode=package