### PR TITLE
Add the ability to get vendor subsidiary relationships

### DIFF
--- a/netsuitesdk/api/vendor_subsidiary_relationships.py
+++ b/netsuitesdk/api/vendor_subsidiary_relationships.py
@@ -1,0 +1,14 @@
+from .base import ApiBase
+
+
+class VendorSubsidiaryRelationships(ApiBase):
+    SIMPLE_FIELDS = [
+    ]
+
+    RECORD_REF_FIELDS = [
+        'entity',
+        'subsidiary',
+    ]
+
+    def __init__(self, ns_client):
+        ApiBase.__init__(self, ns_client=ns_client, type_name='VendorSubsidiaryRelationship')

--- a/netsuitesdk/connection.py
+++ b/netsuitesdk/connection.py
@@ -29,6 +29,7 @@ from .api.terms import Terms
 from .api.tax_items import TaxItems
 from .api.tax_groups import TaxGroups
 from .api.price_level import PriceLevel
+from .api.vendor_subsidiary_relationships import VendorSubsidiaryRelationships
 from .internal.client import NetSuiteClient
 
 
@@ -77,3 +78,4 @@ class NetSuiteConnection:
         self.credit_memos = CreditMemos(ns_client)
         self.price_level = PriceLevel(ns_client)
         self.usages = Usage(ns_client)
+        self.vendor_subsidiary_relationships = VendorSubsidiaryRelationships(ns_client)

--- a/netsuitesdk/internal/constants.py
+++ b/netsuitesdk/internal/constants.py
@@ -87,6 +87,7 @@ SEARCH_RECORD_TYPES = [
     'usage',
     'vendor',
     'vendorCategory',
+    'vendorSubsidiaryRelationship',
     'winLossReason',
 ]
 """ As defined in `SearchRecordType` in https://webservices.netsuite.com/xsd/platform/v2017_2_0/coreTypes.xsd"""

--- a/netsuitesdk/internal/netsuite_types.py
+++ b/netsuitesdk/internal/netsuite_types.py
@@ -83,7 +83,8 @@ COMPLEX_TYPES = {
         'Customer', 'CustomerSearch', 'CustomerTaxRegistrationList', 'CustomerTaxRegistration',
         'Vendor', 'VendorSearch',
         'Job', 'JobSearch',
-        'VendorAddressbook', 'VendorAddressbookList', 'BillingAccountSearch', 'VendorCurrencyList'
+        'VendorAddressbook', 'VendorAddressbookList', 'BillingAccountSearch', 'VendorCurrencyList',
+        'VendorSubsidiaryRelationshipSearch',
     ],
 
     # urn:accounting_2017_2.lists.webservices.netsuite.com


### PR DESCRIPTION
Vendors have a single subsidiary field but can be associated with multiple subsidiaries. That information is stored in a type called VendorSubsidiaryRelationship[^1]. This enables using VendorSubsidiaryRelationshipSearch[^2] via the SDK.

This will allow us to sync vendors in one pass and update the vendor's subsidiaries in another pass.

[^1]: https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2022_1/schema/record/vendorsubsidiaryrelationship.html
[^2]: https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2022_1/schema/search/vendorsubsidiaryrelationshipsearch.html?mode=package