### PR TITLE
Add the ability to post, and post_batch vendor subsidiary relationships

### DIFF
--- a/netsuitesdk/api/vendor_subsidiary_relationships.py
+++ b/netsuitesdk/api/vendor_subsidiary_relationships.py
@@ -1,10 +1,9 @@
+from collections import OrderedDict
+
 from .base import ApiBase
 
 
 class VendorSubsidiaryRelationships(ApiBase):
-    SIMPLE_FIELDS = [
-    ]
-
     RECORD_REF_FIELDS = [
         'entity',
         'subsidiary',
@@ -12,3 +11,19 @@ class VendorSubsidiaryRelationships(ApiBase):
 
     def __init__(self, ns_client):
         ApiBase.__init__(self, ns_client=ns_client, type_name='VendorSubsidiaryRelationship')
+
+    def _build_vendor_subsidiary_relationship(self, data) -> OrderedDict:
+        assert data['externalId'], 'missing external id'
+        vsr = self.ns_client.VendorSubsidiaryRelationship(externalId=data['externalId'])
+        self.build_record_ref_fields(self.RECORD_REF_FIELDS, data, vsr)
+        return vsr
+
+    def post(self, data) -> OrderedDict:
+        vsr = self._build_vendor_subsidiary_relationship(data)
+        response = self.ns_client.upsert(vsr)
+        return self._serialize(response)
+
+    def post_batch(self, records) -> [OrderedDict]:
+        vsrs = [self._build_vendor_subsidiary_relationship(record) for record in records]
+        responses = self.ns_client.upsert_list(vsrs)
+        return [self._serialize(response) for response in responses]

--- a/netsuitesdk/internal/netsuite_types.py
+++ b/netsuitesdk/internal/netsuite_types.py
@@ -84,6 +84,7 @@ COMPLEX_TYPES = {
         'Vendor', 'VendorSearch',
         'Job', 'JobSearch',
         'VendorAddressbook', 'VendorAddressbookList', 'BillingAccountSearch', 'VendorCurrencyList',
+        'VendorSubsidiaryRelationship',
         'VendorSubsidiaryRelationshipSearch',
     ],
 


### PR DESCRIPTION
It isn't possible to create a vendor with multiple subsidiary relationships during Vendor POST, however we can POST VendorSubsidiaryRelationships after we create the vendor to end up with a multi sub vendor. 
This is for [ACC-393](https://linear.app/journal/issue/ACC-393/we-need-to-find-a-way-to-create-vendors-with-multiple-subsidiaries).
After this is in we can update our NetSuite vendor creation logic to take multiple subsidiaries. 