### PR TITLE
Update WSDL to 2024.1

### DIFF
--- a/netsuitesdk/internal/client.py
+++ b/netsuitesdk/internal/client.py
@@ -26,8 +26,8 @@ class NetSuiteClient:
     """The Netsuite client class providing access to the Netsuite
     SOAP/WSDL web service"""
 
-    WSDL_URL_TEMPLATE = 'https://{account}.suitetalk.api.netsuite.com/wsdl/v2019_1_0/netsuite.wsdl'
-    DATACENTER_URL_TEMPLATE = 'https://{account}.suitetalk.api.netsuite.com/services/NetSuitePort_2019_1'
+    WSDL_URL_TEMPLATE = 'https://{account}.suitetalk.api.netsuite.com/wsdl/v2024_1_0/netsuite.wsdl'
+    DATACENTER_URL_TEMPLATE = 'https://{account}.suitetalk.api.netsuite.com/services/NetSuitePort_2024_1'
 
     _search_preferences = None
     _passport = None
@@ -75,7 +75,7 @@ class NetSuiteClient:
 
         # default service points to wrong data center. need to create a new service proxy and replace the default one
         self._service_proxy = self._client.create_service(
-            '{urn:platform_2019_1.webservices.netsuite.com}NetSuiteBinding', self._datacenter_url)
+            '{urn:platform_2024_1.webservices.netsuite.com}NetSuiteBinding', self._datacenter_url)
 
         # Parse all complex types specified in :const:`~netsuitesdk.netsuite_types.COMPLEX_TYPES`
         # and store them as attributes of this instance. Same for simple types.


### PR DESCRIPTION
There is a difference here, that when you get subsidiaries they include subsidiary currencies. In 2019.1 Netsuite populated the currency internal id field with the currency name. This meant in our code we looked up currencies by their name instead of their id. They fixed this at some point between now and then, so our application code will need to change at the same time we change the version here.

Other than that everything seems to work the same. There is an error log about Passport not being a type. That appears to be related to this:

![image](https://github.com/user-attachments/assets/3efbcd9f-7173-4f90-b0e8-e312e37ecdc0)

We use TBA but this library I guess has some usage of Passport (we don't use it). Because we try to load the type, it results in an error log.

I tried to remove the type, but then things didn't seem to work right. We should probably eventually get to the bottom of this, but it may make more sense to figure out how to handle the upgrades to the original library (3.0 will default to 2024.1 WSDL).  Right now our primary concern is fixing the deprecation warnings our customers are receiving for using this old WSDL.